### PR TITLE
Bump lowest puppet version to 4.10.5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.10.5 < 6.0.0"
     }
   ],
   "pdk-version": "0.5.0",


### PR DESCRIPTION
Translation work was added to Puppet version 4.10.5 and above, hence bumping the requirement for what this module works with.