### PR TITLE
pdksync - (MODULES-7658) use beaker3 in puppet-module-gems

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -12,6 +12,3 @@ appveyor.yml:
 Gemfile:
   required:
     ':system_tests':
-      - gem: beaker
-        version: '~> 3.13'
-        from_env: BEAKER_VERSION

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.13')
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
(MODULES-7658) use beaker3 in puppet-module-gems
pdk version: `1.6.1` 
