### PR TITLE
pdksync - FM-8499 remove ubuntu 14 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
         "16.04"
       ]
     },

--- a/provision.yaml
+++ b/provision.yaml
@@ -3,7 +3,7 @@ default:
   images: ['redhat-8-x86_64']
 travis_deb:
   provisioner: docker
-  images: ['debian:8', 'debian:9', 'ubuntu:14.04', 'ubuntu:16.04', 'ubuntu:18.04']  
+  images: ['debian:8', 'debian:9', 'ubuntu:16.04', 'ubuntu:18.04']  
 travis_el:
   provisioner: docker 
   images: ['centos:6', 'centos:7', 'oraclelinux:6', 'oraclelinux:7', 'scientificlinux/sl:6', 'scientificlinux/sl:7']


### PR DESCRIPTION
FM-8499 remove ubuntu 14 support
pdk version: `1.14.1` 
