### PR TITLE
Add CentOS 5-7 and Ubuntu 18.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,9 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
+        "5",
+        "6",
+        "7",
         "8"
       ]
     },
@@ -36,7 +39,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     },
     {


### PR DESCRIPTION
Red Hat 5-7 is listed so it's odd to leave those out. This also marks Ubuntu 18.04 as supported.