### PR TITLE
pdksync - Use abs instead of vmpooler to provision test resources

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -1,5 +1,5 @@
 default:
-  provisioner: vmpooler
+  provisioner: abs
   images: ['redhat-8-x86_64']
 vagrant:
   provisioner: vagrant
@@ -17,5 +17,5 @@ travis_el7:
   provisioner: docker 
   images: ['waffleimage/centos7', 'waffleimage/oraclelinux7', 'waffleimage/scientificlinux7']
 release_checks:
-  provisioner: vmpooler
+  provisioner: abs
   images: ['debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-8-x86_64', 'sles-11-x86_64', 'sles-12-x86_64', 'win-2008r2-x86_64', 'win-2016-core-x86_64', 'win-2012r2-core-x86_64', 'win-10-ent-x86_64']


### PR DESCRIPTION
Use abs instead of vmpooler to provision test resources
pdk version: `1.17.0` 
